### PR TITLE
fix: resolve configuration validation error in auto setup workflow

### DIFF
--- a/internal/setup/config.go
+++ b/internal/setup/config.go
@@ -461,8 +461,9 @@ func (g *DefaultConfigGenerator) GenerateFromDetected(ctx context.Context) (*Con
 
 	// Create base configuration
 	gatewayConfig := &config.GatewayConfig{
-		Port:    8080,
-		Servers: []config.ServerConfig{},
+		Port:                  8080,
+		MaxConcurrentRequests: 100, // Set default value to pass validation
+		Servers:               []config.ServerConfig{},
 	}
 
 	// Generate configuration for each detected and compatible runtime

--- a/tests/mocks/config_generator_mock.go
+++ b/tests/mocks/config_generator_mock.go
@@ -63,7 +63,8 @@ func (m *MockConfigGenerator) GenerateFromDetected(ctx context.Context) (*setup.
 
 	return &setup.ConfigGenerationResult{
 		Config: &config.GatewayConfig{
-			Port: 8080,
+			Port:                  8080,
+			MaxConcurrentRequests: 100,
 			Servers: []config.ServerConfig{
 				{
 					Name:      "go-lsp",
@@ -152,8 +153,9 @@ func (m *MockConfigGenerator) GenerateForRuntime(ctx context.Context, runtime st
 
 	return &setup.ConfigGenerationResult{
 		Config: &config.GatewayConfig{
-			Port:    8080,
-			Servers: servers,
+			Port:                  8080,
+			MaxConcurrentRequests: 100,
+			Servers:               servers,
 		},
 		DetectionReport:  nil,
 		ServersGenerated: len(servers),
@@ -182,7 +184,8 @@ func (m *MockConfigGenerator) GenerateMultiLanguageConfig(ctx context.Context, p
 	// Default implementation - return multi-language config with common servers
 	return &setup.ConfigGenerationResult{
 		Config: &config.GatewayConfig{
-			Port: 8080,
+			Port:                  8080,
+			MaxConcurrentRequests: 100,
 			Servers: []config.ServerConfig{
 				{
 					Name:      "go-lsp",
@@ -235,7 +238,8 @@ func (m *MockConfigGenerator) GenerateDefault() (*setup.ConfigGenerationResult, 
 
 	return &setup.ConfigGenerationResult{
 		Config: &config.GatewayConfig{
-			Port: 8080,
+			Port:                  8080,
+			MaxConcurrentRequests: 100,
 			Servers: []config.ServerConfig{
 				{
 					Name:      "go-lsp",
@@ -266,8 +270,9 @@ func (m *MockConfigGenerator) UpdateConfig(existing *config.GatewayConfig, updat
 	}
 
 	updatedConfig := &config.GatewayConfig{
-		Port:    existing.Port,
-		Servers: make([]config.ServerConfig, len(existing.Servers)),
+		Port:                  existing.Port,
+		MaxConcurrentRequests: existing.MaxConcurrentRequests,
+		Servers:               make([]config.ServerConfig, len(existing.Servers)),
 	}
 	copy(updatedConfig.Servers, existing.Servers)
 

--- a/tests/testdata/test_helpers.go
+++ b/tests/testdata/test_helpers.go
@@ -148,8 +148,9 @@ func CreateMockVerificationResult(runtime, version, path string, installed, comp
 
 func CreateMockGatewayConfig(port int, servers []config.ServerConfig) *config.GatewayConfig {
 	return &config.GatewayConfig{
-		Port:    port,
-		Servers: servers,
+		Port:                  port,
+		MaxConcurrentRequests: 100,
+		Servers:               servers,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix critical bug where MaxConcurrentRequests was not initialized in GenerateFromDetected()
- Resolves "max concurrent requests must be positive: 0" validation failures
- Updates all mock configurations and test helpers to include required field

## Test plan
- [x] Auto setup unit tests pass (5/5)
- [x] Integration tests no longer fail with validation error
- [x] E2E tests execute successfully
- [x] Configuration generation works correctly in real scenarios