### PR TITLE
chore: rename nodejs to javascript in server log

### DIFF
--- a/src/cli/server_commands.go
+++ b/src/cli/server_commands.go
@@ -35,7 +35,7 @@ func RunServer(addr string, configPath string, lspOnly bool) error {
 	// Display SCIP cache status
 	displayGatewayCacheStatus(gateway)
 
-	common.CLILogger.Info("Available languages: go, python, nodejs, typescript, java")
+	common.CLILogger.Info("Available languages: go, python, javascript, typescript, java")
 	common.CLILogger.Info("HTTP JSON-RPC endpoint: http://%s/jsonrpc", addr)
 	common.CLILogger.Info("Health check endpoint: http://%s/health", addr)
 


### PR DESCRIPTION
## Summary
- replace `nodejs` with `javascript` in `RunServer` startup log

## Testing
- `go test ./...` *(fails: lsp-gateway binary not found; run 'make local' first)*

------
https://chatgpt.com/codex/tasks/task_e_68957d139718832a9e8253721ce53af7