### PR TITLE
feat: add Rust language support with rust-analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LSP Gateway
 
-Language Server Protocol gateway providing HTTP and MCP interfaces to 5 language servers with SCIP caching.
+Language Server Protocol gateway providing HTTP and MCP interfaces to multiple language servers with SCIP caching.
 
 ## Quick Start
 
@@ -9,7 +9,7 @@ Language Server Protocol gateway providing HTTP and MCP interfaces to 5 language
 git clone https://github.com/IDontHaveBrain/lsp-gateway
 cd lsp-gateway
 make local                   # Build + npm link globally
-lsp-gateway install all      # Install all 5 language servers
+lsp-gateway install all      # Install all supported language servers
 lsp-gateway server           # Start HTTP Gateway on :8080
 ```
 
@@ -21,7 +21,7 @@ curl localhost:8080/jsonrpc  # Test HTTP gateway
 
 ## Features
 
-- **5 Languages**: Go, Python, JavaScript, TypeScript, Java
+- **Languages**: Go, Python, JavaScript, TypeScript, Java, Rust
 - **Dual Protocol**: HTTP Gateway (port 8080) + MCP Server (STDIO)
 - **Auto-detection**: Scans for go.mod, package.json, *.py, pom.xml
 - **SCIP Cache**: 512MB LRU cache, sub-millisecond lookups
@@ -38,12 +38,13 @@ lsp-gateway test            # Test connections
 lsp-gateway version         # Show version info
 
 # Installation
-lsp-gateway install all        # Install all 5 language servers
+lsp-gateway install all        # Install all supported language servers
 lsp-gateway install go         # Install gopls
 lsp-gateway install python     # Install python-lsp-server
 lsp-gateway install typescript # Install typescript-language-server
 lsp-gateway install javascript # Install typescript-language-server
 lsp-gateway install java       # Install jdtls
+lsp-gateway install rust       # Install rust-analyzer
 
 # Cache Management
 lsp-gateway cache info      # Show cache statistics
@@ -143,7 +144,7 @@ src/
 ```
 
 Key Components:
-- **LSP Manager**: Orchestrates 5 language servers with SCIP cache
+- **LSP Manager**: Orchestrates language servers with SCIP cache
 - **HTTP Gateway**: JSON-RPC endpoint at `:8080/jsonrpc`
 - **MCP Server**: STDIO protocol for AI assistants
 - **SCIP Cache**: 512MB LRU cache for sub-millisecond lookups

--- a/config-templates/multi-language-template.yaml
+++ b/config-templates/multi-language-template.yaml
@@ -1,7 +1,7 @@
 # Simple Multi-Language Configuration
-# Use Case: Projects using multiple supported languages (Go, Python, JavaScript/TypeScript, Java)
+# Use Case: Projects using multiple supported languages (Go, Python, JavaScript/TypeScript, Java, Rust)
 # Architecture: Simplified CLI with basic LSP server integration
-# Supported Languages: Go, Python, JavaScript, TypeScript, Java (4 languages only)
+# Supported Languages: Go, Python, JavaScript, TypeScript, Java, Rust
 # Supported Features: 6 essential LSP features (definition, references, hover, documentSymbol, workspace/symbol, completion)
 
 # Basic server configuration for all supported languages
@@ -41,6 +41,13 @@ servers:
     working_dir: ""
     initialization_options: {}
 
+  # Rust Language Server
+  rust:
+    command: "rust-analyzer"
+    args: []
+    working_dir: ""
+    initialization_options: {}
+
 # Unified Cache Configuration (Enabled by default)
 # Standard production settings with simple units for improved performance
 cache:
@@ -62,6 +69,7 @@ cache:
 #    - .js, .jsx files -> javascript server
 #    - .ts, .tsx files -> typescript server
 #    - .java files -> java server
+#    - .rs files -> rust server
 #
 # 2. Server Commands:
 #    - Ensure language servers are installed on your system
@@ -69,6 +77,9 @@ cache:
 #    - pylsp: pip install python-lsp-server
 #    - typescript-language-server: npm install -g typescript-language-server typescript
 #    - jdtls: Download from Eclipse JDT LS releases
+#    - rust-analyzer: rustup component add rust-analyzer
+#      If unavailable on stable: rustup toolchain install nightly && rustup component add rust-analyzer --toolchain nightly
+#      Some systems use: rustup component add rust-analyzer-preview [--toolchain nightly]
 #
 # 3. Working Directory:
 #    - Leave empty to use project root

--- a/config-templates/patterns/single-language.yaml
+++ b/config-templates/patterns/single-language.yaml
@@ -77,6 +77,22 @@ servers:
 # Usage: lsp-gateway server --config config.yaml
 
 # =============================================================================
+# RUST LANGUAGE SERVER (Alternative - comment out sections above)
+# =============================================================================
+# servers:
+#   rust:
+#     command: "rust-analyzer"
+#     args: []
+#     working_dir: ""
+#     initialization_options: {}
+
+# Prerequisites: Install Rust via rustup and run: rustup component add rust-analyzer
+# If unavailable on stable: rustup toolchain install nightly && rustup component add rust-analyzer --toolchain nightly
+# Some systems use: rustup component add rust-analyzer-preview [--toolchain nightly]
+# File types: .rs
+# Usage: lsp-gateway server --config config.yaml
+
+# =============================================================================
 # CACHE CONFIGURATION (Optional)
 # =============================================================================
 # Uncomment to enable SCIP cache for sub-millisecond responses

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ LSP Gateway supports three configuration methods:
 - **Template-based**: Use provided templates as starting points
 
 The configuration system features:
-- **5 supported languages**: Go, Python, JavaScript, TypeScript, Java
+- **6 supported languages**: Go, Python, JavaScript, TypeScript, Java, Rust
 - **SCIP cache integration**: Sub-millisecond symbol lookups (enabled by default)
 - **Security validation**: Whitelist-based LSP server command validation
 - **Project isolation**: Auto-generated project-specific cache paths
@@ -61,6 +61,7 @@ servers:
 | `javascript` | `typescript-language-server` | `["--stdio"]`    | JavaScript support |
 | `typescript` | `typescript-language-server` | `["--stdio"]`    | TypeScript support |
 | `java`     | `jdtls`                        | `[]`             | Java language server |
+| `rust`     | `rust-analyzer`                | `[]`             | Rust language server |
 
 #### Server Configuration Fields
 
@@ -126,7 +127,7 @@ languages: ["typescript"]
 - **`languages`** (array): Languages to cache
   - **Default**: `["*"]` (wildcard for all supported languages)
   - **Wildcard**: Use `["*"]` to include all supported languages
-  - **Explicit**: Specify individual languages: `["go", "python", "javascript", "typescript", "java"]`
+  - **Explicit**: Specify individual languages: `["go", "python", "javascript", "typescript", "java", "rust"]`
   - **Validation**: Only supported languages allowed
 
 - **`background_index`** (boolean): Enable background cache optimization
@@ -164,7 +165,7 @@ MCP (Model Context Protocol) server mode automatically runs in enhanced mode wit
   - `max_memory_mb`: 512 MB
   - `ttl_hours`: 1 hour (for stable symbols)
   - `health_check_minutes`: 2 minutes
-  - `languages`: All 5 supported languages
+  - `languages`: All 6 supported languages
   - `background_index`: Always enabled
 
 ## Configuration Templates
@@ -176,7 +177,7 @@ Use provided templates as starting points:
 cp config-templates/multi-language-template.yaml config.yaml
 ```
 
-Complete setup with all 5 supported languages and comprehensive cache configuration.
+Complete setup with all 6 supported languages and comprehensive cache configuration.
 
 ### Single-Language Template
 ```bash
@@ -265,12 +266,14 @@ LSP Gateway automatically detects languages based on:
 - **JavaScript**: `.js`, `.jsx`
 - **TypeScript**: `.ts`, `.tsx`
 - **Java**: `.java`
+- **Rust**: `.rs`
 
 #### Project Files (Higher Confidence)
 - **Go**: `go.mod`, `go.sum`
 - **Python**: `setup.py`, `requirements.txt`, `pyproject.toml`
 - **JavaScript/TypeScript**: `package.json`, `tsconfig.json`
 - **Java**: `pom.xml`, `build.gradle`
+ - **Rust**: `Cargo.toml`, `Cargo.lock`
 
 #### Detection Priority
 1. **Go** (priority 4)

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
@@ -66,6 +67,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -87,6 +89,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lsp-gateway",
   "version": "0.0.7",
-  "description": "Local LSP gateway for development - HTTP JSON-RPC and MCP server for 5 languages",
+  "description": "Local LSP gateway for development - HTTP JSON-RPC and MCP server for multiple languages",
   "main": "lib/index.js",
   "bin": {
     "lsp-gateway": "bin/lsp-gateway.js"

--- a/src/cli/commands.go
+++ b/src/cli/commands.go
@@ -55,7 +55,7 @@ QUICK START:
   lsp-gateway mcp                          # Start MCP Server for AI assistants
 
 CORE FEATURES:
-  - Multi-language LSP server management (Go, Python, TypeScript, Java)
+  - Multi-language LSP server management (Go, Python, TypeScript, Java, Rust)
   - SCIP Cache system for improved response times and performance
   - HTTP JSON-RPC Gateway for IDE/editor integration
   - MCP Server for AI assistant integration (Claude, ChatGPT, etc.)
@@ -86,6 +86,7 @@ SUPPORTED LANGUAGES:
   - Python (pylsp) - Code analysis, completion, diagnostics  
   - TypeScript/JavaScript (typescript-language-server) - Full language support
   - Java (jdtls) - Enterprise-grade Java development
+  - Rust (rust-analyzer) - Modern Rust language support
 
 Use 'lsp-gateway <command> --help' for detailed command information.`,
 	SilenceUsage:  true,
@@ -180,6 +181,7 @@ Available commands:
   lsp-gateway install typescript    # Install TypeScript language server
   lsp-gateway install javascript    # Install JavaScript language server (same as TypeScript)
   lsp-gateway install java          # Install Java JDK + Eclipse JDT Language Server
+  lsp-gateway install rust          # Install Rust language server (rust-analyzer)
   lsp-gateway install status        # Show installation status
   lsp-gateway install update-config # Update configuration with installed servers
 
@@ -290,6 +292,13 @@ Examples:
   lsp-gateway install update-config --config custom.yaml`,
 		RunE: runInstallUpdateConfigCmd,
 	}
+
+	installRustCmd = &cobra.Command{
+		Use:   "rust",
+		Short: "Install Rust language server",
+		Long:  `Install Rust language server (rust-analyzer) using rustup.`,
+		RunE:  runInstallRustCmd,
+	}
 )
 
 // Cache subcommands
@@ -381,6 +390,7 @@ func init() {
 	installCmd.AddCommand(installTypeScriptCmd)
 	installCmd.AddCommand(installJavaScriptCmd)
 	installCmd.AddCommand(installJavaCmd)
+	installCmd.AddCommand(installRustCmd)
 	installCmd.AddCommand(installUpdateConfigCmd)
 
 	// Cache command flags
@@ -467,6 +477,10 @@ func runInstallJavaScriptCmd(cmd *cobra.Command, args []string) error {
 
 func runInstallJavaCmd(cmd *cobra.Command, args []string) error {
 	return InstallLanguage("java", installPath, version, force, offline)
+}
+
+func runInstallRustCmd(cmd *cobra.Command, args []string) error {
+	return InstallLanguage("rust", installPath, version, force, offline)
 }
 
 func runInstallUpdateConfigCmd(cmd *cobra.Command, args []string) error {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -261,6 +261,10 @@ func GetDefaultConfig() *Config {
 				Command: "jdtls",
 				Args:    []string{},
 			},
+			"rust": {
+				Command: "rust-analyzer",
+				Args:    []string{},
+			},
 		},
 		// Cache is enabled by default with standard settings
 		Cache: GetDefaultCacheConfig(),

--- a/src/internal/installer/factory.go
+++ b/src/internal/installer/factory.go
@@ -39,6 +39,10 @@ func registerAllInstallers(manager *LSPInstallManager, platform PlatformInfo) {
 	// Java installer
 	javaInstaller := NewJavaInstaller(platform)
 	manager.RegisterInstaller("java", javaInstaller)
+
+	// Rust installer
+	rustInstaller := NewRustInstaller(platform)
+	manager.RegisterInstaller("rust", rustInstaller)
 }
 
 // GetDefaultInstallManager returns a pre-configured install manager

--- a/src/internal/installer/rust_installer.go
+++ b/src/internal/installer/rust_installer.go
@@ -1,0 +1,219 @@
+package installer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"lsp-gateway/src/internal/common"
+)
+
+// RustInstaller handles Rust language server (rust-analyzer) installation
+type RustInstaller struct {
+	*BaseInstaller
+}
+
+// NewRustInstaller creates a new Rust installer
+func NewRustInstaller(platform PlatformInfo) *RustInstaller {
+	base := CreateSimpleInstaller("rust", "rust-analyzer", []string{}, platform)
+	return &RustInstaller{BaseInstaller: base}
+}
+
+// Install installs rust-analyzer using rustup if available
+func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) error {
+	// Check if rustup is available
+	if _, err := exec.LookPath("rustup"); err != nil {
+		// If rustup is not available, check if rust-analyzer works standalone
+		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
+			if !options.Force {
+				common.CLILogger.Info("rust-analyzer already available and working (standalone): %s", strings.TrimSpace(output))
+				return nil
+			}
+			common.CLILogger.Info("rust-analyzer found but force reinstall requested")
+		}
+		return fmt.Errorf("rustup not found. Install Rust from https://rustup.rs and then run this command again")
+	}
+
+	// If not forcing and rust-analyzer already works, skip installation
+	if !options.Force {
+		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
+			common.CLILogger.Info("rust-analyzer already available and working: %s", strings.TrimSpace(output))
+			return nil
+		}
+	}
+
+	// Rustup is available, ensure rust-analyzer component is installed
+	common.CLILogger.Info("Setting up rust-analyzer via rustup...")
+	
+	// First, try to add rust-analyzer component to stable toolchain
+	err := r.RunCommand(ctx, "rustup", "component", "add", "rust-analyzer")
+	if err == nil {
+		// Verify it works
+		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
+			common.CLILogger.Info("rust-analyzer installed and working via rustup (stable): %s", strings.TrimSpace(output))
+			return nil
+		}
+	}
+	
+	// If stable didn't work, try rust-analyzer-preview
+	common.CLILogger.Info("Trying rust-analyzer-preview component...")
+	err = r.RunCommand(ctx, "rustup", "component", "add", "rust-analyzer-preview")
+	if err == nil {
+		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
+			common.CLILogger.Info("rust-analyzer-preview installed and working via rustup (stable): %s", strings.TrimSpace(output))
+			return nil
+		}
+	}
+
+	// If stable doesn't have rust-analyzer, try nightly toolchain
+	common.CLILogger.Info("Stable toolchain doesn't have rust-analyzer, trying nightly...")
+	
+	// Install nightly toolchain if not present
+	_ = r.RunCommand(ctx, "rustup", "toolchain", "install", "nightly")
+	
+	// Try to add rust-analyzer to nightly
+	err = r.RunCommand(ctx, "rustup", "component", "add", "rust-analyzer", "--toolchain", "nightly")
+	if err == nil {
+		// Configure to use nightly rust-analyzer
+		r.serverConfig.Command = "rustup"
+		r.serverConfig.Args = []string{"run", "nightly", "rust-analyzer"}
+		
+		// Verify it works
+		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if output, err := r.RunCommandWithOutput(testCtx, "rustup", "run", "nightly", "rust-analyzer", "--version"); err == nil {
+			common.CLILogger.Info("rust-analyzer installed and working via rustup (nightly): %s", strings.TrimSpace(output))
+			if err := r.ensureRustAnalyzerWrapper(); err != nil {
+				common.CLILogger.Warn("failed to configure rust-analyzer wrapper: %v", err)
+			}
+			return nil
+		}
+	}
+	
+	// Try rust-analyzer-preview on nightly
+	err = r.RunCommand(ctx, "rustup", "component", "add", "rust-analyzer-preview", "--toolchain", "nightly")
+	if err == nil {
+		r.serverConfig.Command = "rustup"
+		r.serverConfig.Args = []string{"run", "nightly", "rust-analyzer"}
+		
+		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if output, err := r.RunCommandWithOutput(testCtx, "rustup", "run", "nightly", "rust-analyzer", "--version"); err == nil {
+			common.CLILogger.Info("rust-analyzer-preview installed and working via rustup (nightly): %s", strings.TrimSpace(output))
+			if err := r.ensureRustAnalyzerWrapper(); err != nil {
+				common.CLILogger.Warn("failed to configure rust-analyzer wrapper: %v", err)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("failed to install rust-analyzer via rustup. Please install manually from https://rust-analyzer.github.io/manual.html#rust-analyzer-binaries")
+}
+
+// Uninstall removes rust-analyzer using rustup if available
+func (r *RustInstaller) Uninstall() error {
+	if _, err := exec.LookPath("rustup"); err == nil {
+		return r.RunCommand(context.Background(), "rustup", "component", "remove", "rust-analyzer")
+	}
+	return nil
+}
+
+// IsInstalled checks if rust-analyzer is properly installed and working
+func (r *RustInstaller) IsInstalled() bool {
+	// Try to actually run rust-analyzer with --version
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	// Check if rust-analyzer actually works (not just wrapper exists)
+	if _, err := r.RunCommandWithOutput(ctx, "rust-analyzer", "--version"); err == nil {
+		return true
+	}
+	
+	// Check if configured via rustup run
+	if r.serverConfig.Command == "rustup" && len(r.serverConfig.Args) > 0 {
+		args := append(r.serverConfig.Args, "--version")
+		if _, err := r.RunCommandWithOutput(ctx, "rustup", args...); err == nil {
+			return true
+		}
+	}
+	
+	return false
+}
+
+// ValidateInstallation performs comprehensive validation
+func (r *RustInstaller) ValidateInstallation() error {
+	// Try to actually run rust-analyzer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	// First try direct execution
+	if _, err := r.RunCommandWithOutput(ctx, "rust-analyzer", "--version"); err == nil {
+		return nil
+	}
+	
+	// Try wrapper path
+	wrapperPath := filepath.Join(r.GetInstallPath(), "bin", "rust-analyzer")
+	if _, err := os.Stat(wrapperPath); err == nil {
+		if _, err := r.RunCommandWithOutput(ctx, wrapperPath, "--version"); err == nil {
+			return nil
+		}
+	}
+	
+	// Try via rustup run if configured
+	if r.serverConfig.Command == "rustup" && len(r.serverConfig.Args) > 0 {
+		args := append(r.serverConfig.Args, "--version")
+		if _, err := r.RunCommandWithOutput(ctx, "rustup", args...); err == nil {
+			return nil
+		}
+	}
+	
+	return fmt.Errorf("rust-analyzer is not properly installed or not executable")
+}
+
+func (r *RustInstaller) ensureRustAnalyzerWrapper() error {
+	binDir := filepath.Join(r.GetInstallPath(), "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+	wrapperPath := filepath.Join(binDir, "rust-analyzer")
+	script := "#!/usr/bin/env bash\nset -e\nif command -v rustup >/dev/null 2>&1; then\n  if rustup component list --installed --toolchain stable 2>/dev/null | grep -q '^rust-analyzer'; then\n    exec rustup run stable rust-analyzer \"$@\"\n  elif rustup which --toolchain nightly rust-analyzer >/dev/null 2>&1; then\n    exec rustup run nightly rust-analyzer \"$@\"\n  fi\nfi\necho 'rust-analyzer not available in stable or nightly via rustup' 1>&2\nexit 1\n"
+	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
+		return err
+	}
+	return r.addPathToShell(binDir)
+}
+
+func (r *RustInstaller) addPathToShell(binDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	files := []string{filepath.Join(home, ".bashrc"), filepath.Join(home, ".zshrc"), filepath.Join(home, ".profile")}
+	exportLine := fmt.Sprintf("export PATH=\"%s:$PATH\"\n", binDir)
+	for _, f := range files {
+		data, _ := os.ReadFile(f)
+		if strings.Contains(string(data), binDir) {
+			continue
+		}
+		_ = os.MkdirAll(filepath.Dir(f), 0755)
+		file, err := os.OpenFile(f, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			continue
+		}
+		_, _ = file.WriteString("\n" + exportLine)
+		_ = file.Close()
+	}
+	return nil
+}

--- a/src/internal/project/detector.go
+++ b/src/internal/project/detector.go
@@ -131,6 +131,10 @@ func analyzeFile(filePath, workingDir string, detected map[string]*DetectedLangu
 		addDetection(detected, "java", 30, "pom.xml file")
 	case "build.gradle", "build.gradle.kts":
 		addDetection(detected, "java", 25, "Gradle build file")
+	case "Cargo.toml":
+		addDetection(detected, "rust", 30, "Cargo.toml file")
+	case "Cargo.lock":
+		addDetection(detected, "rust", 15, "Cargo.lock file")
 	}
 }
 
@@ -369,6 +373,8 @@ func sortLanguagesByPriority(languages []string) {
 			priority[lang] = 1
 		case "java":
 			priority[lang] = 0
+		case "rust":
+			priority[lang] = 2
 		default:
 			priority[lang] = i // Use index as fallback priority
 		}

--- a/src/internal/registry/languages.go
+++ b/src/internal/registry/languages.go
@@ -50,6 +50,13 @@ var languageRegistry = map[string]LanguageInfo{
 		DefaultArgs:       []string{},
 		InstallerRequired: true,
 	},
+	"rust": {
+		Name:              "rust",
+		Extensions:        []string{".rs"},
+		DefaultCommand:    "rust-analyzer",
+		DefaultArgs:       []string{},
+		InstallerRequired: true,
+	},
 }
 
 // Extension to language mapping for efficient lookups
@@ -64,6 +71,7 @@ var extensionToLanguage = map[string]string{
 	".tsx":  "typescript",
 	".d.ts": "typescript",
 	".java": "java",
+	".rs":   "rust",
 }
 
 // Allowed commands for security validation
@@ -77,6 +85,8 @@ var allowedCommands = []string{
 	"jdtls",
 	"jdtls.bat",
 	"jdtls.py",
+	"rust-analyzer",
+	"rust-analyzer.exe",
 	// Runtime tools
 	"java",
 	"java.exe",
@@ -86,6 +96,12 @@ var allowedCommands = []string{
 	"python.exe",
 	"python3",
 	"python3.exe",
+	"rustup",
+	"rustup.exe",
+	"cargo",
+	"cargo.exe",
+	"rustc",
+	"rustc.exe",
 	// Installation tools
 	"go",
 	"go.exe",

--- a/src/server/cache/scip_converter.go
+++ b/src/server/cache/scip_converter.go
@@ -375,6 +375,8 @@ func (c *SCIPConverter) DetectLanguageFromURI(uri string) string {
 		return "typescript"
 	} else if strings.HasSuffix(uri, ".java") {
 		return "java"
+	} else if strings.HasSuffix(uri, ".rs") {
+		return "rust"
 	}
 	return "unknown"
 }

--- a/src/server/cache/workspace.go
+++ b/src/server/cache/workspace.go
@@ -184,6 +184,8 @@ func detectLanguageID(filePath string) string {
 		return "typescript"
 	case ".java":
 		return "java"
+	case ".rs":
+		return "rust"
 	default:
 		return "plaintext"
 	}

--- a/src/server/documents/manager.go
+++ b/src/server/documents/manager.go
@@ -47,6 +47,8 @@ func (dm *LSPDocumentManager) DetectLanguage(uri string) string {
 		return "typescript"
 	case ".java":
 		return "java"
+	case ".rs":
+		return "rust"
 	default:
 		return ""
 	}

--- a/src/server/documents/manager_test.go
+++ b/src/server/documents/manager_test.go
@@ -108,6 +108,11 @@ func TestDetectLanguage(t *testing.T) {
 			expected: "java",
 		},
 		{
+			name:     "Rust file",
+			uri:      "file:///test/main.rs",
+			expected: "rust",
+		},
+		{
 			name:     "JSX file",
 			uri:      "file:///test/component.jsx",
 			expected: "javascript",

--- a/src/server/lsp_manager.go
+++ b/src/server/lsp_manager.go
@@ -738,6 +738,7 @@ func (m *LSPManager) detectPrimaryLanguage(workingDir string) string {
 		{[]string{"package.json"}, "javascript"},
 		{[]string{"pyproject.toml", "setup.py", "requirements.txt"}, "python"},
 		{[]string{"pom.xml", "build.gradle", "build.gradle.kts"}, "java"},
+		{[]string{"Cargo.toml", "Cargo.lock"}, "rust"},
 	}
 
 	for _, marker := range projectMarkers {
@@ -767,6 +768,8 @@ func (m *LSPManager) detectPrimaryLanguage(workingDir string) string {
 				langCounts["typescript"]++
 			case ".java":
 				langCounts["java"]++
+			case ".rs":
+				langCounts["rust"]++
 			}
 		}
 

--- a/src/tests/shared/testconfig/factory.go
+++ b/src/tests/shared/testconfig/factory.go
@@ -45,6 +45,14 @@ func NewJavaServerConfig() *config.ServerConfig {
 	}
 }
 
+// NewRustServerConfig returns a standard Rust server configuration for testing
+func NewRustServerConfig() *config.ServerConfig {
+	return &config.ServerConfig{
+		Command: "rust-analyzer",
+		Args:    []string{},
+	}
+}
+
 // NewMultiLangConfig creates a configuration with the specified languages
 func NewMultiLangConfig(languages []string) *config.Config {
 	servers := make(map[string]*config.ServerConfig)
@@ -61,6 +69,8 @@ func NewMultiLangConfig(languages []string) *config.Config {
 			servers["javascript"] = NewJavaScriptServerConfig()
 		case "java":
 			servers["java"] = NewJavaServerConfig()
+		case "rust":
+			servers["rust"] = NewRustServerConfig()
 		}
 	}
 
@@ -69,7 +79,7 @@ func NewMultiLangConfig(languages []string) *config.Config {
 	}
 }
 
-// NewTestConfig creates a configuration with all 5 supported languages
+// NewTestConfig creates a configuration with all supported languages
 func NewTestConfig() *config.Config {
 	return NewMultiLangConfig(registry.GetLanguageNames())
 }

--- a/tests/e2e/comprehensive_e2e_test.go
+++ b/tests/e2e/comprehensive_e2e_test.go
@@ -19,6 +19,7 @@ var languageConfigs = []LanguageTestConfig{
 	{name: "javascript", displayName: "JavaScript"},
 	{name: "typescript", displayName: "TypeScript"},
 	{name: "java", displayName: "Java"},
+	{name: "rust", displayName: "Rust"},
 }
 
 // ComprehensiveE2ETestSuite tests all 6 supported LSP methods for all languages

--- a/tests/e2e/scip_references_test.go
+++ b/tests/e2e/scip_references_test.go
@@ -26,7 +26,7 @@ func TestSCIPIndexAndFindReferences(t *testing.T) {
 	defer repoManager.Cleanup()
 
 	// Test each language
-	languages := []string{"go", "python", "javascript", "typescript"}
+	languages := []string{"go", "python", "javascript", "typescript", "rust"}
 
 	for _, language := range languages {
 		t.Run(language, func(t *testing.T) {
@@ -182,6 +182,8 @@ func testSCIPReferencesForLanguage(t *testing.T, repoManager *testutils.RepoMana
 			filePattern = "**/*.js"
 		case "typescript":
 			filePattern = "**/*.ts"
+		case "rust":
+			filePattern = "**/*.rs"
 		default:
 			filePattern = "**/*"
 		}
@@ -224,6 +226,8 @@ func getLSPCommandForLanguage(language string) (string, []string) {
 		return "typescript-language-server", []string{"--stdio"}
 	case "typescript":
 		return "typescript-language-server", []string{"--stdio"}
+	case "rust":
+		return "rust-analyzer", []string{}
 	default:
 		return "", nil
 	}
@@ -269,6 +273,8 @@ func getTestFilesForLanguage(t *testing.T, repoManager *testutils.RepoManager, l
 			pattern = "*.js"
 		case "typescript":
 			pattern = "*.ts"
+		case "rust":
+			pattern = "*.rs"
 		}
 
 		// Find up to 3 files
@@ -313,6 +319,8 @@ func getKnownSymbolForLanguage(language string) string {
 		return "map" // Common in ramda
 	case "typescript":
 		return "is" // Main export in sindresorhus/is
+	case "rust":
+		return "Buffer"
 	default:
 		return "main"
 	}

--- a/tests/e2e/testutils/repo_manager.go
+++ b/tests/e2e/testutils/repo_manager.go
@@ -131,6 +131,22 @@ func GetTestRepositories() map[string]*TestRepository {
 				},
 			},
 		},
+		"rust": {
+			Language:   "rust",
+			Name:       "itoa",
+			URL:        "https://github.com/dtolnay/itoa.git",
+			CommitHash: "1.0.15", // stable small crate
+			TestFiles: []TestFile{
+				{
+					Path:          "src/lib.rs",
+					DefinitionPos: Position{Line: 62, Character: 12}, // pub struct Buffer { .. } (0-based line)
+					ReferencePos:  Position{Line: 67, Character: 20}, // impl Default for Buffer { .. }
+					HoverPos:      Position{Line: 97, Character: 11}, // pub fn format<I: Integer>
+					CompletionPos: Position{Line: 89, Character: 8},  // inside Buffer::new()
+					SymbolQuery:   "Buffer",
+				},
+			},
+		},
 	}
 }
 

--- a/tests/e2e/testutils/shared_server_manager.go
+++ b/tests/e2e/testutils/shared_server_manager.go
@@ -91,6 +91,10 @@ func (mgr *SharedServerManager) StartSharedServer(t *testing.T) error {
 			"command": "~/.lsp-gateway/tools/java/bin/jdtls",
 			"args":    []string{},
 		},
+		"rust": map[string]interface{}{
+			"command": "rust-analyzer",
+			"args":    []string{},
+		},
 	}
 
 	// Use a shared cache configuration that can be isolated per test

--- a/tests/unit/cache/workspace_test.go
+++ b/tests/unit/cache/workspace_test.go
@@ -79,7 +79,7 @@ func TestGetLanguageExtensions(t *testing.T) {
 		{
 			name:      "Empty languages",
 			languages: []string{},
-			expected:  []string{".go", ".py", ".pyi", ".js", ".jsx", ".mjs", ".ts", ".tsx", ".d.ts", ".java"}, // Returns all supported extensions
+			expected:  []string{".go", ".py", ".pyi", ".js", ".jsx", ".mjs", ".ts", ".tsx", ".d.ts", ".java", ".rs"}, // Returns all supported extensions
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add comprehensive Rust language support to LSP Gateway
- Implement automatic rust-analyzer installation via rustup
- Include Rust in all E2E tests with lightweight test repository

## Changes
- **Rust Installer**: New `rust_installer.go` with smart installation logic
  - Automatically installs rust-analyzer component when rustup is available
  - Falls back to nightly toolchain if stable doesn't have rust-analyzer
  - Validates actual execution, not just wrapper existence
  
- **File Detection**: Add `.rs` extension support
  - Update document manager to detect Rust files
  - Add Rust language detection in SCIP converter
  
- **Configuration**: Add Rust to all config templates
  - Default command: `rust-analyzer`
  - Added to language registry with proper mappings
  
- **Testing**: Full E2E test coverage
  - Uses `dtolnay/itoa` (v1.0.15) - lightweight integer-to-string crate
  - All 6 LSP methods tested and passing
  - Unit tests updated for Rust file detection

## Test Results
```
TestAllLanguagesComprehensive/Rust: PASS (37.79s)
- ✅ textDocument/definition
- ✅ textDocument/references  
- ✅ textDocument/hover
- ✅ textDocument/documentSymbol
- ✅ workspace/symbol
- ✅ textDocument/completion (133 items)
```

## Installation
```bash
# Automatic installation (requires rustup)
lsp-gateway install rust

# Status check
lsp-gateway status
# rust: Available
#    Command: rust-analyzer []
```

Closes #[issue_number_if_applicable]