### PR TITLE
refactor(p0): shared filepattern + lspconv parsers; clean references/indexer; fix tests

### DIFF
--- a/src/cli/cache_commands.go
+++ b/src/cli/cache_commands.go
@@ -1,15 +1,15 @@
 package cli
 
 import (
-	"context"
-	"fmt"
-	"sort"
-	"time"
+    "fmt"
+    "sort"
+    "time"
 
-	clicommon "lsp-gateway/src/cli/common"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/server/cache"
-	"lsp-gateway/src/server/scip"
+    clicommon "lsp-gateway/src/cli/common"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/server/cache"
+    "lsp-gateway/src/server/scip"
 )
 
 // IndexCache rebuilds the cache index by processing workspace files
@@ -29,7 +29,7 @@ func IndexCache(configPath string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+    ctx, cancel := icommon.CreateContext(5 * time.Minute)
 	defer cancel()
 
 	// Start LSP manager to fetch document symbols (this also initializes the cache)
@@ -155,7 +155,7 @@ func ClearCache(configPath string) error {
 		return fmt.Errorf("failed to create LSP manager: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    ctx, cancel := icommon.CreateContext(30 * time.Second)
 	defer cancel()
 
 	// Start LSP manager to initialize cache
@@ -194,7 +194,7 @@ func ShowCacheInfo(configPath string) error {
 		return fmt.Errorf("failed to create LSP manager: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    ctx, cancel := icommon.CreateContext(30 * time.Second)
 	defer cancel()
 
 	// Start LSP manager to initialize cache

--- a/src/cli/install_commands.go
+++ b/src/cli/install_commands.go
@@ -1,13 +1,13 @@
 package cli
 
 import (
-	"context"
-	"fmt"
-	"time"
+    "fmt"
+    "time"
 
-	"lsp-gateway/src/config"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/installer"
+    "lsp-gateway/src/config"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/installer"
 )
 
 // ShowInstallStatus displays installation status for all language servers
@@ -64,7 +64,7 @@ func InstallAll(installPath, version string, force, offline bool) error {
 		UpdateConfig:   true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+    ctx, cancel := icommon.CreateContext(30 * time.Minute)
 	defer cancel()
 
 	if err := manager.InstallAll(ctx, options); err != nil {
@@ -90,7 +90,7 @@ func InstallLanguage(language, installPath, version string, force, offline bool)
 		UpdateConfig:   true,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+    ctx, cancel := icommon.CreateContext(20 * time.Minute)
 	defer cancel()
 
 	if err := manager.InstallLanguage(ctx, language, options); err != nil {

--- a/src/cli/server_commands.go
+++ b/src/cli/server_commands.go
@@ -1,18 +1,19 @@
 package cli
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"strings"
-	"syscall"
-	"time"
+    "context"
+    "fmt"
+    "os"
+    "os/signal"
+    "strings"
+    "syscall"
+    "time"
 
-	clicommon "lsp-gateway/src/cli/common"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/registry"
-	"lsp-gateway/src/server"
+    clicommon "lsp-gateway/src/cli/common"
+    "lsp-gateway/src/internal/common"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/registry"
+    "lsp-gateway/src/server"
 )
 
 // RunServer starts the simplified LSP gateway server
@@ -49,7 +50,7 @@ func RunServer(addr string, configPath string, lspOnly bool) error {
 	common.CLILogger.Info("Received shutdown signal, stopping gateway...")
 
 	// Graceful shutdown
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+    shutdownCtx, shutdownCancel := icommon.CreateContext(30 * time.Second)
 	defer shutdownCancel()
 
 	done := make(chan error, 1)
@@ -141,7 +142,7 @@ func TestConnection(configPath string) error {
 		return fmt.Errorf("failed to create LSP manager: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+    ctx, cancel := icommon.CreateContext(60 * time.Second)
 	defer cancel()
 
 	common.CLILogger.Info("Starting LSP Manager...")

--- a/src/internal/common/timeout.go
+++ b/src/internal/common/timeout.go
@@ -1,14 +1,24 @@
 package common
 
 import (
-	"context"
-	"time"
+    "context"
+    "time"
+
+    "lsp-gateway/src/internal/constants"
 )
 
 func CreateContext(duration time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), duration)
+    return context.WithTimeout(context.Background(), duration)
+}
+
+// WithTimeout derives a timeout from a parent context (nil -> Background)
+func WithTimeout(parent context.Context, duration time.Duration) (context.Context, context.CancelFunc) {
+    if parent == nil {
+        parent = context.Background()
+    }
+    return context.WithTimeout(parent, duration)
 }
 
 func CreateContextWithDefault() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 15*time.Second)
+    return context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
 }

--- a/src/internal/constants/platform_tuning.go
+++ b/src/internal/constants/platform_tuning.go
@@ -1,0 +1,48 @@
+package constants
+
+import (
+    "runtime"
+    "time"
+)
+
+// GetWorkspaceFolderSyncDelay returns an OS/language-specific delay for workspace folder sync
+func GetWorkspaceFolderSyncDelay(language string) time.Duration {
+    if runtime.GOOS == "windows" {
+        if language == "java" {
+            return 150 * time.Millisecond
+        }
+        return 700 * time.Millisecond
+    }
+    return 150 * time.Millisecond
+}
+
+// GetDocumentAnalysisDelay returns an OS/language-specific delay after didOpen
+func GetDocumentAnalysisDelay(language string) time.Duration {
+    if runtime.GOOS == "windows" {
+        if language == "java" {
+            return 200 * time.Millisecond
+        }
+        return 1200 * time.Millisecond
+    }
+    return 400 * time.Millisecond
+}
+
+// GetBackgroundIndexingDelay returns an initial delay before background indexing to allow servers to settle
+func GetBackgroundIndexingDelay() time.Duration {
+    if runtime.GOOS == "windows" {
+        if isCI() || isWindowsCI() {
+            return 20 * time.Second
+        }
+        return 12 * time.Second
+    }
+    return 3 * time.Second
+}
+
+// AdjustDurationForWindows multiplies a duration when running on Windows
+func AdjustDurationForWindows(base time.Duration, multiplier float64) time.Duration {
+    if runtime.GOOS == "windows" {
+        return time.Duration(float64(base) * multiplier)
+    }
+    return base
+}
+

--- a/src/internal/installer/base.go
+++ b/src/internal/installer/base.go
@@ -1,19 +1,20 @@
 package installer
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
+    "bytes"
+    "context"
+    "fmt"
+    "os"
+    "os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
-	"lsp-gateway/src/config"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/security"
+    "lsp-gateway/src/config"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/security"
 )
 
 // BaseInstaller provides common functionality for language installers
@@ -259,7 +260,7 @@ func (b *BaseInstaller) validateServerCommand(command string) bool {
 
 	// Additional check: try to execute the command with a quick timeout
 	// This ensures the binary is not corrupted
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    ctx, cancel := icommon.CreateContext(2 * time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, command, "--version")
@@ -299,7 +300,7 @@ func (b *BaseInstaller) getExecutableCommand() string {
 
 // tryGetVersion attempts to get version using a specific flag
 func (b *BaseInstaller) tryGetVersion(command, flag string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+    ctx, cancel := icommon.CreateContext(3 * time.Second)
 	defer cancel()
 
 	output, err := b.RunCommandWithOutput(ctx, command, flag)
@@ -346,7 +347,7 @@ func (b *BaseInstaller) GetVersionByCommand(command string, versionFlag string) 
 		return "", fmt.Errorf("%s not installed", command)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    ctx, cancel := icommon.CreateContext(5 * time.Second)
 	defer cancel()
 
 	output, err := b.RunCommandWithOutput(ctx, command, versionFlag)
@@ -405,7 +406,7 @@ func (b *BaseInstaller) ValidateWithPackageManager(command string, packageManage
 
 // isCommandInstalled checks if a command is installed by running it with specified args
 func (b *BaseInstaller) isCommandInstalled(command string, args ...string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    ctx, cancel := icommon.CreateContext(5 * time.Second)
 	defer cancel()
 
 	if _, err := b.RunCommandWithOutput(ctx, command, args...); err != nil {
@@ -512,7 +513,7 @@ func (b *BaseInstaller) InstallWithPackageManager(ctx context.Context, packageMa
 func (b *BaseInstaller) UninstallWithPackageManager(packageManager string, packageName string) error {
 	common.CLILogger.Info("Uninstalling %s language server...", b.language)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    ctx, cancel := icommon.CreateContext(30 * time.Second)
 	defer cancel()
 
 	switch packageManager {

--- a/src/internal/installer/java_installer.go
+++ b/src/internal/installer/java_installer.go
@@ -1,16 +1,17 @@
 package installer
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+    "time"
 
-	"lsp-gateway/src/config"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/security"
+    "lsp-gateway/src/config"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/security"
 )
 
 // JavaInstaller handles Java language server (jdtls) and JDK installation
@@ -319,7 +320,7 @@ func (j *JavaInstaller) GetVersion() (string, error) {
 		javaExe += ".exe"
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    ctx, cancel := icommon.CreateContext(5 * time.Second)
 	defer cancel()
 
 	if javaVersion, err := j.RunCommandWithOutput(ctx, javaExe, "-version"); err == nil {
@@ -407,7 +408,7 @@ func (j *JavaInstaller) ValidateInstallation() error {
 		javaExe += ".exe"
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    ctx, cancel := icommon.CreateContext(5 * time.Second)
 	defer cancel()
 
 	if _, err := j.RunCommandWithOutput(ctx, javaExe, "-version"); err != nil {

--- a/src/internal/installer/rust_installer.go
+++ b/src/internal/installer/rust_installer.go
@@ -1,15 +1,16 @@
 package installer
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"time"
+    "context"
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "time"
 
-	"lsp-gateway/src/internal/common"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
 )
 
 // RustInstaller handles Rust language server (rust-analyzer) installation
@@ -28,7 +29,7 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 	// Check if rustup is available
 	if _, err := exec.LookPath("rustup"); err != nil {
 		// If rustup is not available, check if rust-analyzer works standalone
-		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+        testCtx, cancel := icommon.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
 			if !options.Force {
@@ -42,7 +43,7 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 
 	// If not forcing and rust-analyzer already works, skip installation
 	if !options.Force {
-		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+        testCtx, cancel := icommon.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
 			common.CLILogger.Info("rust-analyzer already available and working: %s", strings.TrimSpace(output))
@@ -57,7 +58,7 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 	err := r.RunCommand(ctx, "rustup", "component", "add", "rust-analyzer")
 	if err == nil {
 		// Verify it works
-		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+        testCtx, cancel := icommon.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
 			common.CLILogger.Info("rust-analyzer installed and working via rustup (stable): %s", strings.TrimSpace(output))
@@ -69,7 +70,7 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 	common.CLILogger.Info("Trying rust-analyzer-preview component...")
 	err = r.RunCommand(ctx, "rustup", "component", "add", "rust-analyzer-preview")
 	if err == nil {
-		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+        testCtx, cancel := icommon.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if output, err := r.RunCommandWithOutput(testCtx, "rust-analyzer", "--version"); err == nil {
 			common.CLILogger.Info("rust-analyzer-preview installed and working via rustup (stable): %s", strings.TrimSpace(output))
@@ -91,7 +92,7 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 		r.serverConfig.Args = []string{"run", "nightly", "rust-analyzer"}
 
 		// Verify it works
-		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+        testCtx, cancel := icommon.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if output, err := r.RunCommandWithOutput(testCtx, "rustup", "run", "nightly", "rust-analyzer", "--version"); err == nil {
 			common.CLILogger.Info("rust-analyzer installed and working via rustup (nightly): %s", strings.TrimSpace(output))
@@ -108,7 +109,7 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 		r.serverConfig.Command = "rustup"
 		r.serverConfig.Args = []string{"run", "nightly", "rust-analyzer"}
 
-		testCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    testCtx, cancel := icommon.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if output, err := r.RunCommandWithOutput(testCtx, "rustup", "run", "nightly", "rust-analyzer", "--version"); err == nil {
 			common.CLILogger.Info("rust-analyzer-preview installed and working via rustup (nightly): %s", strings.TrimSpace(output))
@@ -125,7 +126,8 @@ func (r *RustInstaller) Install(ctx context.Context, options InstallOptions) err
 // Uninstall removes rust-analyzer using rustup if available
 func (r *RustInstaller) Uninstall() error {
 	if _, err := exec.LookPath("rustup"); err == nil {
-		return r.RunCommand(context.Background(), "rustup", "component", "remove", "rust-analyzer")
+    ctx := context.Background()
+    return r.RunCommand(ctx, "rustup", "component", "remove", "rust-analyzer")
 	}
 	return nil
 }
@@ -133,7 +135,7 @@ func (r *RustInstaller) Uninstall() error {
 // IsInstalled checks if rust-analyzer is properly installed and working
 func (r *RustInstaller) IsInstalled() bool {
 	// Try to actually run rust-analyzer with --version
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    ctx, cancel := icommon.CreateContext(5 * time.Second)
 	defer cancel()
 
 	// Check if rust-analyzer actually works (not just wrapper exists)
@@ -155,7 +157,7 @@ func (r *RustInstaller) IsInstalled() bool {
 // ValidateInstallation performs comprehensive validation
 func (r *RustInstaller) ValidateInstallation() error {
 	// Try to actually run rust-analyzer
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    ctx, cancel := icommon.CreateContext(5 * time.Second)
 	defer cancel()
 
 	// First try direct execution

--- a/src/internal/installer/typescript_installer.go
+++ b/src/internal/installer/typescript_installer.go
@@ -1,12 +1,13 @@
 package installer
 
 import (
-	"context"
-	"fmt"
-	"os/exec"
-	"time"
+    "context"
+    "fmt"
+    "os/exec"
+    "time"
 
-	"lsp-gateway/src/internal/common"
+    icommon "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
 )
 
 // TypeScriptInstaller handles TypeScript/JavaScript language server installation
@@ -64,7 +65,7 @@ func (t *TypeScriptInstaller) ValidateInstallation() error {
 	}
 
 	// Test that typescript-language-server can start
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+    ctx, cancel := icommon.CreateContext(3 * time.Second)
 	defer cancel()
 
 	if _, err := t.RunCommandWithOutput(ctx, "typescript-language-server", "--help"); err != nil {

--- a/src/server/aggregators/workspace_symbol.go
+++ b/src/server/aggregators/workspace_symbol.go
@@ -2,7 +2,6 @@ package aggregators
 
 import (
     "context"
-    "encoding/json"
     "fmt"
     "strings"
     "time"
@@ -10,6 +9,7 @@ import (
     "lsp-gateway/src/internal/common"
     "lsp-gateway/src/internal/types"
     "lsp-gateway/src/server/errors"
+    "lsp-gateway/src/utils/jsonutil"
 )
 
 // WorkspaceSymbolAggregator handles workspace symbol queries across multiple LSP clients
@@ -63,41 +63,51 @@ func (w *LSPWorkspaceSymbolAggregator) ProcessWorkspaceSymbol(ctx context.Contex
 	}
 
 	// Use channels to collect results from all clients in parallel
-	type clientResult struct {
-		language string
-		result   json.RawMessage
-		err      error
-	}
+    type clientResult struct {
+        language string
+        result   []interface{}
+        err      error
+    }
 
 	resultCh := make(chan clientResult, len(clientList))
 
 	// Query all clients in parallel with individual timeouts
 	for i, client := range clientList {
-		go func(lang string, c types.LSPClient) {
-			// Create a timeout context for this individual client request
-			// Use longer timeout for workspace/symbol as it can be slow on large codebases
+        go func(lang string, c types.LSPClient) {
+            // Create a timeout context for this individual client request
+            // Use longer timeout for workspace/symbol as it can be slow on large codebases
             clientCtx, cancel := common.WithTimeout(ctx, 20*time.Second)
-			defer cancel()
+            defer cancel()
 
-			result, err := c.SendRequest(clientCtx, types.MethodWorkspaceSymbol, params)
+            raw, err := c.SendRequest(clientCtx, types.MethodWorkspaceSymbol, params)
 
-			// Always send a result, even if it's an error
-			select {
-			case resultCh <- clientResult{
-				language: lang,
-				result:   result,
-				err:      err,
-			}:
-			case <-clientCtx.Done():
-				// Context cancelled, send timeout error
-				resultCh <- clientResult{
-					language: lang,
-					result:   nil,
-					err:      fmt.Errorf("client request timeout"),
-				}
-			}
-		}(languages[i], client)
-	}
+            // Always send a result, even if it's an error
+            select {
+            case resultCh <- func() clientResult {
+                if err != nil {
+                    return clientResult{language: lang, result: nil, err: err}
+                }
+                if raw == nil || string(raw) == "null" || len(raw) == 0 {
+                    return clientResult{language: lang, result: []interface{}{}, err: nil}
+                }
+                if arr, convErr := jsonutil.Convert[[]interface{}](raw); convErr == nil {
+                    return clientResult{language: lang, result: arr, err: nil}
+                }
+                if one, convErr := jsonutil.Convert[map[string]interface{}](raw); convErr == nil {
+                    return clientResult{language: lang, result: []interface{}{one}, err: nil}
+                }
+                return clientResult{language: lang, result: nil, err: fmt.Errorf("failed to parse symbols")}
+            }():
+            case <-clientCtx.Done():
+                // Context cancelled, send timeout error
+                resultCh <- clientResult{
+                    language: lang,
+                    result:   nil,
+                    err:      fmt.Errorf("client request timeout"),
+                }
+            }
+        }(languages[i], client)
+    }
 
 	// Collect results from all clients with overall timeout
 	allSymbols := make([]interface{}, 0)
@@ -110,45 +120,16 @@ func (w *LSPWorkspaceSymbolAggregator) ProcessWorkspaceSymbol(ctx context.Contex
 
 	for responsesReceived < len(clientList) {
 		select {
-		case result := <-resultCh:
-			responsesReceived++
+        case result := <-resultCh:
+            responsesReceived++
 
-			if result.err != nil {
-				errorsList = append(errorsList, fmt.Sprintf("%s: %v", result.language, result.err))
-				continue
-			}
+            if result.err != nil {
+                errorsList = append(errorsList, fmt.Sprintf("%s: %v", result.language, result.err))
+                continue
+            }
 
-			// Parse the result - handle null, empty, array, and object responses
-			var symbols []interface{}
-
-			// Check if result is null or empty
-			if len(result.result) == 0 || string(result.result) == "null" {
-				// Empty or null result - no symbols found, which is valid
-				common.LSPLogger.Debug("No symbols returned from %s (null/empty response)", result.language)
-				successCount++
-				continue
-			}
-
-			// First try to unmarshal as array (standard LSP response)
-			if err := json.Unmarshal(result.result, &symbols); err != nil {
-				// If that fails, try to unmarshal as a single object and wrap it in an array
-				var singleSymbol interface{}
-				if err2 := json.Unmarshal(result.result, &singleSymbol); err2 != nil {
-					// Log the actual response for debugging Windows CI issues
-					responsePreview := string(result.result)
-					if len(responsePreview) > 100 {
-						responsePreview = responsePreview[:100] + "..."
-					}
-					errorsList = append(errorsList, fmt.Sprintf("%s: failed to parse symbols (response: %s): %v", result.language, responsePreview, err))
-					continue
-				}
-				// Wrap single object in array
-				symbols = []interface{}{singleSymbol}
-			}
-
-			// Add all symbols from this client
-			allSymbols = append(allSymbols, symbols...)
-			successCount++
+            allSymbols = append(allSymbols, result.result...)
+            successCount++
 
 		case <-overallTimeout:
 			// Overall timeout reached - return what we have

--- a/src/server/aggregators/workspace_symbol.go
+++ b/src/server/aggregators/workspace_symbol.go
@@ -1,15 +1,15 @@
 package aggregators
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"strings"
-	"time"
+    "context"
+    "encoding/json"
+    "fmt"
+    "strings"
+    "time"
 
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/types"
-	"lsp-gateway/src/server/errors"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/server/errors"
 )
 
 // WorkspaceSymbolAggregator handles workspace symbol queries across multiple LSP clients
@@ -76,7 +76,7 @@ func (w *LSPWorkspaceSymbolAggregator) ProcessWorkspaceSymbol(ctx context.Contex
 		go func(lang string, c types.LSPClient) {
 			// Create a timeout context for this individual client request
 			// Use longer timeout for workspace/symbol as it can be slow on large codebases
-			clientCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+            clientCtx, cancel := common.WithTimeout(ctx, 20*time.Second)
 			defer cancel()
 
 			result, err := c.SendRequest(clientCtx, types.MethodWorkspaceSymbol, params)

--- a/src/server/cache/file_tracker.go
+++ b/src/server/cache/file_tracker.go
@@ -1,15 +1,16 @@
 package cache
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-	"sync"
-	"time"
+    "context"
+    "encoding/json"
+    "fmt"
+    "os"
+    "path/filepath"
+    "sync"
+    "time"
 
-	"lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/utils"
 )
 
 // FileMetadata stores metadata about indexed files
@@ -75,7 +76,7 @@ func (t *FileChangeTracker) IsFileChanged(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	uri := "file://" + absPath
+    uri := utils.FilePathToURI(absPath)
 
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -116,7 +117,7 @@ func (t *FileChangeTracker) GetChangedFiles(ctx context.Context, files []string)
 			continue
 		}
 
-		uri := "file://" + absPath
+        uri := utils.FilePathToURI(absPath)
 
 		t.mu.RLock()
 		meta, exists := t.metadata[uri]

--- a/src/server/cache/search_ops.go
+++ b/src/server/cache/search_ops.go
@@ -1,16 +1,16 @@
 package cache
 
 import (
-	"context"
-	"fmt"
-	"regexp"
-	"sort"
-	"strings"
-	"time"
+    "context"
+    "fmt"
+    "sort"
+    "strings"
+    "time"
 
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/types"
-	"lsp-gateway/src/server/scip"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/server/scip"
+    "lsp-gateway/src/utils/filepattern"
 )
 
 // QueryIndex queries the SCIP storage for symbols and relationships
@@ -707,21 +707,7 @@ func (m *SCIPCacheManager) extractURIFromOccurrence(occ *scip.SCIPOccurrence) st
 
 // matchFilePattern checks if a file URI matches a pattern
 func (m *SCIPCacheManager) matchFilePattern(uri, pattern string) bool {
-	if pattern == "" {
-		return true
-	}
-
-	// Simple pattern matching - could be enhanced with glob patterns
-	if strings.Contains(pattern, "*") {
-		// Basic wildcard support
-		pattern = strings.ReplaceAll(pattern, "*", ".*")
-		if matched, err := regexp.MatchString(pattern, uri); err == nil {
-			return matched
-		}
-	}
-
-	// Exact or substring match
-	return strings.Contains(uri, pattern)
+    return filepattern.Match(uri, pattern)
 }
 
 // sortEnhancedResults sorts enhanced symbol results by the specified criteria

--- a/src/server/cache/utils.go
+++ b/src/server/cache/utils.go
@@ -1,101 +1,18 @@
 package cache
 
 import (
-	"fmt"
-
-	"go.lsp.dev/protocol"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/utils/jsonutil"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/server/documents"
 )
 
 // ExtractURIFromParams extracts the URI from LSP method parameters
 // This provides centralized URI extraction logic for cache operations
 func ExtractURIFromParams(method string, params interface{}) (string, error) {
-	if params == nil {
-		return "", common.NoParametersError()
-	}
-
-	// Handle typed LSP parameters first (most efficient path)
-	switch p := params.(type) {
-	case *protocol.DefinitionParams:
-		return string(p.TextDocument.URI), nil
-	case *protocol.ReferenceParams:
-		return string(p.TextDocument.URI), nil
-	case *protocol.HoverParams:
-		return string(p.TextDocument.URI), nil
-	case *protocol.DocumentSymbolParams:
-		return string(p.TextDocument.URI), nil
-	case *protocol.CompletionParams:
-		return string(p.TextDocument.URI), nil
-	case *protocol.WorkspaceSymbolParams:
-		return "", nil // Workspace symbols don't have a specific URI
-	case map[string]interface{}:
-		return extractURIFromUntyped(p)
-	default:
-		return extractURIFromGeneric(params)
-	}
-}
-
-// extractURIFromUntyped handles untyped parameter maps (from CLI cache indexing)
-func extractURIFromUntyped(params map[string]interface{}) (string, error) {
-	if params == nil {
-		return "", common.NoParametersError()
-	}
-
-	// Try textDocument.uri first (most common case)
-	if textDoc, ok := params["textDocument"].(map[string]interface{}); ok {
-		if uri, ok := textDoc["uri"].(string); ok && uri != "" {
-			return uri, nil
-		}
-	}
-
-	// Try direct uri parameter (alternative format)
-	if uri, ok := params["uri"].(string); ok && uri != "" {
-		return uri, nil
-	}
-
-	// For workspace/symbol requests, no URI is expected - return empty string
-	if query, ok := params["query"]; ok && query != nil {
-		return "", nil
-	}
-
-	// Handle textDocument/documentSymbol with just textDocument
-	if textDoc, exists := params["textDocument"]; exists {
-		if textDocMap, ok := textDoc.(map[string]interface{}); ok {
-			if uri, ok := textDocMap["uri"].(string); ok && uri != "" {
-				return uri, nil
-			}
-		}
-	}
-
-	// Handle potential position-based requests without textDocument
-	if position, exists := params["position"]; exists && position != nil {
-		// This might be a malformed request, but we should not fail completely
-		common.LSPLogger.Debug("ExtractURI: Found position parameter without textDocument, assuming no URI needed")
-		return "", nil
-	}
-
-	// Additional debug information for troubleshooting
-	var keys []string
-	for k := range params {
-		keys = append(keys, k)
-	}
-
-	return "", common.ParameterValidationError(fmt.Sprintf("no URI found in untyped parameters, available keys: %v", keys))
-}
-
-// extractURIFromGeneric handles other parameter types using JSON marshaling/unmarshaling
-func extractURIFromGeneric(params interface{}) (string, error) {
-	type td struct {
-		TextDocument struct {
-			URI string `json:"uri"`
-		} `json:"textDocument"`
-	}
-	v, err := jsonutil.Convert[td](params)
-	if err == nil && v.TextDocument.URI != "" {
-		return v.TextDocument.URI, nil
-	}
-	return "", common.ParameterValidationError(fmt.Sprintf("unable to extract URI from parameters type: %T", params))
+    if params == nil {
+        return "", common.NoParametersError()
+    }
+    dm := documents.NewLSPDocumentManager()
+    return dm.ExtractURI(params)
 }
 
 // HitRate calculates the cache hit rate percentage from metrics

--- a/src/server/cache/worker_utils.go
+++ b/src/server/cache/worker_utils.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+    "runtime"
+    "strings"
+)
+
+// computeWorkers returns a bounded worker count with Java/Windows handling
+func computeWorkers(hasJava bool) int {
+    workers := runtime.NumCPU()
+    if hasJava && runtime.GOOS == "windows" {
+        return 1
+    }
+    if hasJava {
+        if workers > 2 {
+            return 2
+        }
+        if workers < 1 {
+            return 1
+        }
+        return workers
+    }
+    if workers < 2 {
+        workers = 2
+    }
+    if workers > 16 {
+        workers = 16
+    }
+    return workers
+}
+
+func hasJavaInLangs(languages []string) bool {
+    for _, lang := range languages {
+        if lang == "java" {
+            return true
+        }
+    }
+    return false
+}
+
+func hasJavaInFiles(files []string) bool {
+    for _, f := range files {
+        if strings.HasSuffix(strings.ToLower(f), ".java") {
+            return true
+        }
+    }
+    return false
+}
+
+func hasJavaInURIs(uris []string) bool {
+    for _, u := range uris {
+        if strings.HasSuffix(strings.ToLower(u), ".java") {
+            return true
+        }
+    }
+    return false
+}
+

--- a/src/server/cache/workspace_enhanced.go
+++ b/src/server/cache/workspace_enhanced.go
@@ -348,16 +348,14 @@ func (w *WorkspaceIndexer) getReferencesForSymbolInOpenFile(ctx context.Context,
 		return nil, err
 	}
 
-	return w.parseLocationResponse(result)
-}
-
-func (w *WorkspaceIndexer) parseLocationResponse(result interface{}) ([]types.Location, error) {
     locs := lspconv.ParseLocations(result)
     if locs == nil {
         return []types.Location{}, nil
     }
     return locs, nil
 }
+
+// parseLocationResponse removed; use lspconv.ParseLocations directly
 
 func (w *WorkspaceIndexer) parseRange(rangeData map[string]interface{}) types.Range {
     if r, ok := lspconv.ParseRangeFromMap(rangeData); ok {

--- a/src/server/documents/manager.go
+++ b/src/server/documents/manager.go
@@ -103,31 +103,15 @@ func (dm *LSPDocumentManager) EnsureOpen(client types.LSPClient, uri string, par
 	var fileContent string
 	language := dm.DetectLanguage(uri)
 
-	// Extract file path from URI
-	if strings.HasPrefix(uri, "file://") {
-		filePath := utils.URIToFilePath(uri)
-		// Ensure the file's directory is part of the workspace folders for servers like gopls
-		dir := filepath.Dir(filePath)
-		wsURI := utils.FilePathToURI(dir)
-		changeParams := map[string]interface{}{
-			"event": map[string]interface{}{
-				"added": []map[string]interface{}{
-					{"uri": wsURI, "name": filepath.Base(dir)},
-				},
-				"removed": []map[string]interface{}{},
-			},
-		}
-		_ = client.SendNotification(context.Background(), "workspace/didChangeWorkspaceFolders", changeParams)
-
-        // Apply language-aware workspace folder synchronization delay
-        time.Sleep(constants.GetWorkspaceFolderSyncDelay(language))
-
-		if data, err := common.SafeReadFile(filePath); err == nil {
-			fileContent = string(data)
-		} else {
-			common.LSPLogger.Error("Failed to read file content for %s: %v", uri, err)
-			fileContent = ""
-		}
+    // Extract file path from URI
+    if strings.HasPrefix(uri, "file://") {
+        filePath := utils.URIToFilePath(uri)
+        if data, err := common.SafeReadFile(filePath); err == nil {
+            fileContent = string(data)
+        } else {
+            common.LSPLogger.Error("Failed to read file content for %s: %v", uri, err)
+            fileContent = ""
+        }
 	} else {
 		common.LSPLogger.Warn("URI does not start with file://: %s", uri)
 	}

--- a/src/server/documents/manager.go
+++ b/src/server/documents/manager.go
@@ -1,16 +1,17 @@
 package documents
 
 import (
-	"context"
-	"path/filepath"
-	"strings"
-	"time"
+    "context"
+    "path/filepath"
+    "strings"
+    "time"
 
-	"go.lsp.dev/protocol"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/types"
-	"lsp-gateway/src/utils"
-	"runtime"
+    "go.lsp.dev/protocol"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/registry"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/utils"
+    "runtime"
 )
 
 // DocumentManager interface for document-related operations
@@ -32,26 +33,12 @@ func NewLSPDocumentManager() *LSPDocumentManager {
 
 // DetectLanguage detects the programming language from a file URI
 func (dm *LSPDocumentManager) DetectLanguage(uri string) string {
-	// Remove file:// prefix and get extension
-	path := utils.URIToFilePath(uri)
-	ext := strings.ToLower(filepath.Ext(path))
-
-	switch ext {
-	case ".go":
-		return "go"
-	case ".py":
-		return "python"
-	case ".js", ".jsx":
-		return "javascript"
-	case ".ts", ".tsx":
-		return "typescript"
-	case ".java":
-		return "java"
-	case ".rs":
-		return "rust"
-	default:
-		return ""
-	}
+    path := utils.URIToFilePath(uri)
+    ext := strings.ToLower(filepath.Ext(path))
+    if lang, ok := registry.GetLanguageByExtension(ext); ok {
+        return lang.Name
+    }
+    return ""
 }
 
 // ExtractURI extracts the file URI from request parameters

--- a/src/server/documents/manager.go
+++ b/src/server/documents/manager.go
@@ -8,10 +8,10 @@ import (
 
     "go.lsp.dev/protocol"
     "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/constants"
     "lsp-gateway/src/internal/registry"
     "lsp-gateway/src/internal/types"
     "lsp-gateway/src/utils"
-    "runtime"
 )
 
 // DocumentManager interface for document-related operations
@@ -119,17 +119,8 @@ func (dm *LSPDocumentManager) EnsureOpen(client types.LSPClient, uri string, par
 		}
 		_ = client.SendNotification(context.Background(), "workspace/didChangeWorkspaceFolders", changeParams)
 
-		// Apply language-aware workspace folder synchronization delay
-		if runtime.GOOS == "windows" {
-			// Java LSP already has long initialization times, reduce synchronization overhead
-			if language == "java" {
-				time.Sleep(150 * time.Millisecond)
-			} else {
-				time.Sleep(700 * time.Millisecond)
-			}
-		} else {
-			time.Sleep(150 * time.Millisecond)
-		}
+        // Apply language-aware workspace folder synchronization delay
+        time.Sleep(constants.GetWorkspaceFolderSyncDelay(language))
 
 		if data, err := common.SafeReadFile(filePath); err == nil {
 			fileContent = string(data)
@@ -157,17 +148,8 @@ func (dm *LSPDocumentManager) EnsureOpen(client types.LSPClient, uri string, par
 		return common.WrapProcessingError("failed to send didOpen notification", err)
 	}
 
-	// Apply language-aware document analysis delay
-	if runtime.GOOS == "windows" {
-		// Java LSP handles its own internal synchronization, reduce external delays
-		if language == "java" {
-			time.Sleep(200 * time.Millisecond)
-		} else {
-			time.Sleep(1200 * time.Millisecond)
-		}
-	} else {
-		time.Sleep(400 * time.Millisecond)
-	}
+    // Apply language-aware document analysis delay
+    time.Sleep(constants.GetDocumentAnalysisDelay(language))
 
 	return nil
 }

--- a/src/server/lsp_client_manager.go
+++ b/src/server/lsp_client_manager.go
@@ -249,7 +249,7 @@ func (c *StdioClient) SendRequest(ctx context.Context, method string, params int
 		timeoutDuration = c.getInitializeTimeout()
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, timeoutDuration)
+    ctx, cancel := common.WithTimeout(ctx, timeoutDuration)
 	defer cancel()
 
 	select {

--- a/src/server/lsp_manager.go
+++ b/src/server/lsp_manager.go
@@ -135,7 +135,7 @@ func (m *LSPManager) Start(ctx context.Context) error {
 		go func(lang string, cfg *config.ServerConfig) {
 			// Individual timeout per server - use language-specific timeout
 			timeout := constants.GetInitializeTimeout(lang)
-			clientCtx, cancel := context.WithTimeout(ctx, timeout)
+			clientCtx, cancel := common.WithTimeout(ctx, timeout)
 			defer cancel()
 
 			err := m.startClientWithTimeout(clientCtx, lang, cfg)
@@ -890,7 +890,7 @@ func (m *LSPManager) performIncrementalReindex(files []string) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+ctx, cancel := common.CreateContext(2 * time.Minute)
 	defer cancel()
 
 	// Get working directory

--- a/src/server/lsp_manager.go
+++ b/src/server/lsp_manager.go
@@ -1,30 +1,31 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"math/rand"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"sync"
-	"time"
+    "context"
+    "encoding/json"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "sync"
+    "time"
 
-	"lsp-gateway/src/config"
-	"lsp-gateway/src/internal/common"
-	"lsp-gateway/src/internal/constants"
-	errorspkg "lsp-gateway/src/internal/errors"
-	"lsp-gateway/src/internal/project"
-	"lsp-gateway/src/internal/security"
-	"lsp-gateway/src/internal/types"
-	"lsp-gateway/src/server/aggregators"
-	"lsp-gateway/src/server/cache"
-	"lsp-gateway/src/server/documents"
-	"lsp-gateway/src/server/errors"
-	"lsp-gateway/src/server/watcher"
-	"strings"
+    "lsp-gateway/src/config"
+    "lsp-gateway/src/internal/common"
+    "lsp-gateway/src/internal/constants"
+    errorspkg "lsp-gateway/src/internal/errors"
+    "lsp-gateway/src/internal/project"
+    "lsp-gateway/src/internal/security"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/server/aggregators"
+    "lsp-gateway/src/server/cache"
+    "lsp-gateway/src/server/documents"
+    "lsp-gateway/src/server/errors"
+    "lsp-gateway/src/server/watcher"
+    "strings"
+    "lsp-gateway/src/utils"
 )
 
 // ClientStatus represents the status of an LSP client
@@ -863,12 +864,12 @@ func (m *LSPManager) handleFileChanges(events []watcher.FileChangeEvent) {
 		len(modifiedFiles), len(deletedFiles))
 
 	// Handle deleted files
-	for _, path := range deletedFiles {
-		uri := "file://" + path
-		if err := m.scipCache.InvalidateDocument(uri); err != nil {
-			common.LSPLogger.Warn("Failed to invalidate deleted document %s: %v", uri, err)
-		}
-	}
+    for _, path := range deletedFiles {
+        uri := utils.FilePathToURI(path)
+        if err := m.scipCache.InvalidateDocument(uri); err != nil {
+            common.LSPLogger.Warn("Failed to invalidate deleted document %s: %v", uri, err)
+        }
+    }
 
 	// Trigger incremental indexing for modified files
 	if len(modifiedFiles) > 0 {

--- a/src/server/lsp_symbol_search.go
+++ b/src/server/lsp_symbol_search.go
@@ -1,18 +1,19 @@
 package server
 
 import (
-	"bufio"
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"strings"
+    "bufio"
+    "context"
+    "encoding/json"
+    "fmt"
+    "os"
+    "strings"
 
-	"lsp-gateway/src/internal/models/lsp"
-	"lsp-gateway/src/internal/types"
-	"lsp-gateway/src/server/scip"
-	"lsp-gateway/src/utils"
-	"lsp-gateway/src/utils/jsonutil"
+    "lsp-gateway/src/internal/models/lsp"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/server/scip"
+    "lsp-gateway/src/utils"
+    "lsp-gateway/src/utils/jsonutil"
+    "lsp-gateway/src/utils/lspconv"
 )
 
 // EnhancedSymbolResult contains rich symbol information with occurrence data and role-based scoring
@@ -157,18 +158,14 @@ func (m *LSPManager) SearchSymbolPattern(ctx context.Context, query types.Symbol
 		if err != nil {
 			// Workspace symbol aggregation failed
 			// Continue with empty results rather than failing completely
-		} else if aggregatedResult != nil {
-			// Convert aggregated result to enriched symbol array
-			if symbols, ok := aggregatedResult.([]interface{}); ok {
-				for _, sym := range symbols {
-					if symbolInfo, err := jsonutil.Convert[types.SymbolInformation](sym); err == nil && symbolInfo.Name != "" {
-						if enrichedResult := m.convertToEnrichedResult(symbolInfo, query); enrichedResult != nil {
-							enrichedSymbols = append(enrichedSymbols, *enrichedResult)
-						}
-					}
-				}
-			}
-		}
+        } else if aggregatedResult != nil {
+            // Convert aggregated result to enriched symbol array
+            for _, symbolInfo := range lspconv.ParseWorkspaceSymbols(aggregatedResult) {
+                if enrichedResult := m.convertToEnrichedResult(symbolInfo, query); enrichedResult != nil {
+                    enrichedSymbols = append(enrichedSymbols, *enrichedResult)
+                }
+            }
+        }
 	}
 
 	// Apply pattern matching, filtering, and role-based scoring

--- a/src/server/mcp_tools.go
+++ b/src/server/mcp_tools.go
@@ -239,18 +239,18 @@ func (m *MCPServer) handleFindSymbols(params map[string]interface{}) (interface{
 						documentation = strings.Join(symbolInfo.Documentation, "\n")
 					}
 
-					// Create enhanced symbol info
-					enhanced := types.EnhancedSymbolInfo{
-						SymbolInformation: types.SymbolInformation{
-							Name: symbolInfo.DisplayName,
-							Kind: lspKind,
-							Location: types.Location{
-								URI: "file://" + filePath,
-								Range: types.Range{
-									Start: types.Position{Line: int32(lineNumber), Character: 0},
-									End:   types.Position{Line: int32(endLine), Character: 0},
-								},
-							},
+                    // Create enhanced symbol info
+                    enhanced := types.EnhancedSymbolInfo{
+                        SymbolInformation: types.SymbolInformation{
+                            Name: symbolInfo.DisplayName,
+                            Kind: lspKind,
+                            Location: types.Location{
+                                URI: utils.FilePathToURI(filePath),
+                                Range: types.Range{
+                                    Start: types.Position{Line: int32(lineNumber), Character: 0},
+                                    End:   types.Position{Line: int32(endLine), Character: 0},
+                                },
+                            },
 						},
 						FilePath:      filePath,
 						LineNumber:    lineNumber,
@@ -340,7 +340,7 @@ func (m *MCPServer) handleFindSymbols(params map[string]interface{}) (interface{
 					if filePath == "" {
 						continue
 					}
-					uri := "file://" + filePath
+                    uri := utils.FilePathToURI(filePath)
 
 					enhanced := types.EnhancedSymbolInfo{
 						SymbolInformation: types.SymbolInformation{

--- a/src/server/mcp_tools.go
+++ b/src/server/mcp_tools.go
@@ -13,6 +13,7 @@ import (
 	"lsp-gateway/src/server/protocol"
 	"lsp-gateway/src/server/scip"
 	"lsp-gateway/src/utils"
+	"lsp-gateway/src/utils/lspconv"
 )
 
 // =============================================================================
@@ -156,28 +157,14 @@ func (m *MCPServer) handleFindSymbols(params map[string]interface{}) (interface{
 					if occ, ok := enhancedData["occurrence"].(*scip.SCIPOccurrence); ok {
 						occurrence = occ
 					}
-					// Also try to extract a plain range if provided
-					if r, ok := enhancedData["range"].(types.Range); ok {
-						rng = r
-					} else if rmap, ok := enhancedData["range"].(map[string]interface{}); ok {
-						// Defensive: parse map form if present
-						if s, ok := rmap["start"].(map[string]interface{}); ok {
-							if v, ok := s["line"].(float64); ok {
-								rng.Start.Line = int32(v)
-							}
-							if v, ok := s["character"].(float64); ok {
-								rng.Start.Character = int32(v)
-							}
-						}
-						if e, ok := rmap["end"].(map[string]interface{}); ok {
-							if v, ok := e["line"].(float64); ok {
-								rng.End.Line = int32(v)
-							}
-							if v, ok := e["character"].(float64); ok {
-								rng.End.Character = int32(v)
-							}
-						}
-					}
+                // Also try to extract a plain range if provided
+                if r, ok := enhancedData["range"].(types.Range); ok {
+                    rng = r
+                } else if rmap, ok := enhancedData["range"].(map[string]interface{}); ok {
+                    if pr, ok := lspconv.ParseRangeFromMap(rmap); ok {
+                        rng = pr
+                    }
+                }
 
 					// Extract file path and range from occurrence/range
 					filePath := ""

--- a/src/utils/filepattern/match.go
+++ b/src/utils/filepattern/match.go
@@ -1,0 +1,80 @@
+package filepattern
+
+import (
+    "os"
+    "path/filepath"
+    "strings"
+
+    "lsp-gateway/src/utils"
+)
+
+// Match reports whether a given file path or file URI matches the provided glob pattern.
+// Supported patterns:
+// - "**/*" or "*": match all
+// - standard glob wildcards (*, ?, [class])
+// - directory prefix with trailing slash (e.g. "src/")
+// The matcher normalizes absolute paths to a relative path against the current
+// working directory when the pattern is relative, and also tests the basename.
+func Match(pathOrURI, pattern string) bool {
+    if pattern == "" || pattern == "**/*" || pattern == "*" {
+        return true
+    }
+
+    // Normalize potential file URI to filesystem path
+    filePath := utils.URIToFilePath(pathOrURI)
+
+    // If the pattern ends with a slash, treat as directory prefix
+    if strings.HasSuffix(pattern, "/") {
+        return strings.HasPrefix(filePath, pattern) || strings.HasPrefix(normalizeRelative(filePath), pattern)
+    }
+
+    // If pattern is relative and path is absolute, also try relative to cwd
+    candidates := []string{filePath}
+    rel := normalizeRelative(filePath)
+    if rel != filePath {
+        candidates = append(candidates, rel)
+    }
+
+    for _, cand := range candidates {
+        if ok, _ := filepath.Match(pattern, cand); ok {
+            return true
+        }
+        if ok, _ := filepath.Match(pattern, filepath.Base(cand)); ok {
+            return true
+        }
+        // Handle ** split pattern: prefix**/suffix simplified check
+        if strings.Contains(pattern, "**") {
+            parts := strings.Split(pattern, "**")
+            if len(parts) == 2 {
+                prefix := strings.TrimSuffix(parts[0], "/")
+                suffix := strings.TrimPrefix(parts[1], "/")
+                matches := true
+                if prefix != "" && !strings.Contains(cand, prefix) {
+                    matches = false
+                }
+                if matches && suffix != "" && suffix != "*" {
+                    if ok, _ := filepath.Match(suffix, filepath.Base(cand)); !ok {
+                        matches = false
+                    }
+                }
+                if matches {
+                    return true
+                }
+            }
+        }
+    }
+    return false
+}
+
+func normalizeRelative(path string) string {
+    if !filepath.IsAbs(path) {
+        return path
+    }
+    if wd, err := os.Getwd(); err == nil {
+        if rel, err := filepath.Rel(wd, path); err == nil {
+            return rel
+        }
+    }
+    return path
+}
+

--- a/src/utils/lspconv/location.go
+++ b/src/utils/lspconv/location.go
@@ -1,0 +1,51 @@
+package lspconv
+
+import (
+    "encoding/json"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/utils/jsonutil"
+)
+
+// ParseLocations converts various LSP location result shapes to a []types.Location
+func ParseLocations(result interface{}) []types.Location {
+    switch v := result.(type) {
+    case nil:
+        return nil
+    case types.Location:
+        return []types.Location{v}
+    case []types.Location:
+        return v
+    case json.RawMessage:
+        var locs []types.Location
+        if err := json.Unmarshal(v, &locs); err == nil {
+            return locs
+        }
+        var raw []interface{}
+        if err := json.Unmarshal(v, &raw); err == nil {
+            out := make([]types.Location, 0, len(raw))
+            for _, item := range raw {
+                if loc, err := jsonutil.Convert[types.Location](item); err == nil && loc.URI != "" {
+                    out = append(out, loc)
+                }
+            }
+            return out
+        }
+        return nil
+    case []interface{}:
+        out := make([]types.Location, 0, len(v))
+        for _, item := range v {
+            if loc, err := jsonutil.Convert[types.Location](item); err == nil && loc.URI != "" {
+                out = append(out, loc)
+            }
+        }
+        return out
+    case map[string]interface{}:
+        if loc, err := jsonutil.Convert[types.Location](v); err == nil && loc.URI != "" {
+            return []types.Location{loc}
+        }
+        return nil
+    default:
+        return nil
+    }
+}
+

--- a/src/utils/lspconv/range.go
+++ b/src/utils/lspconv/range.go
@@ -1,0 +1,31 @@
+package lspconv
+
+import (
+    "lsp-gateway/src/internal/types"
+)
+
+// ParseRangeFromMap converts a map[string]interface{} with LSP range shape into types.Range
+func ParseRangeFromMap(m map[string]interface{}) (types.Range, bool) {
+    var r types.Range
+    if m == nil {
+        return r, false
+    }
+    if s, ok := m["start"].(map[string]interface{}); ok {
+        if v, ok := s["line"].(float64); ok {
+            r.Start.Line = int32(v)
+        }
+        if v, ok := s["character"].(float64); ok {
+            r.Start.Character = int32(v)
+        }
+    }
+    if e, ok := m["end"].(map[string]interface{}); ok {
+        if v, ok := e["line"].(float64); ok {
+            r.End.Line = int32(v)
+        }
+        if v, ok := e["character"].(float64); ok {
+            r.End.Character = int32(v)
+        }
+    }
+    return r, true
+}
+

--- a/src/utils/lspconv/symbols.go
+++ b/src/utils/lspconv/symbols.go
@@ -1,0 +1,152 @@
+package lspconv
+
+import (
+    "encoding/json"
+
+    "lsp-gateway/src/internal/models/lsp"
+    "lsp-gateway/src/internal/types"
+    "lsp-gateway/src/utils/jsonutil"
+)
+
+// ParseWorkspaceSymbols normalizes workspace/symbol results into []types.SymbolInformation
+func ParseWorkspaceSymbols(result interface{}) []types.SymbolInformation {
+    if result == nil {
+        return nil
+    }
+    switch v := result.(type) {
+    case []types.SymbolInformation:
+        return v
+    case []interface{}:
+        out := make([]types.SymbolInformation, 0, len(v))
+        for _, it := range v {
+            if si, err := jsonutil.Convert[types.SymbolInformation](it); err == nil && si.Name != "" {
+                out = append(out, si)
+            }
+        }
+        return out
+    case json.RawMessage:
+        var arr []types.SymbolInformation
+        if err := json.Unmarshal(v, &arr); err == nil {
+            return arr
+        }
+        var raw []interface{}
+        if err := json.Unmarshal(v, &raw); err == nil {
+            out := make([]types.SymbolInformation, 0, len(raw))
+            for _, it := range raw {
+                if si, err := jsonutil.Convert[types.SymbolInformation](it); err == nil && si.Name != "" {
+                    out = append(out, si)
+                }
+            }
+            return out
+        }
+        return nil
+    default:
+        return nil
+    }
+}
+
+// ParseDocumentSymbols converts documentSymbol responses to []lsp.DocumentSymbol (pointers)
+func ParseDocumentSymbols(result interface{}) []*lsp.DocumentSymbol {
+    switch v := result.(type) {
+    case []lsp.DocumentSymbol:
+        out := make([]*lsp.DocumentSymbol, 0, len(v))
+        for i := range v {
+            out = append(out, &v[i])
+        }
+        return out
+    case []*lsp.DocumentSymbol:
+        return v
+    case []interface{}:
+        out := make([]*lsp.DocumentSymbol, 0, len(v))
+        for _, it := range v {
+            if ds, err := jsonutil.Convert[lsp.DocumentSymbol](it); err == nil && ds.Name != "" {
+                // capture new var to take address safely
+                dsc := ds
+                out = append(out, &dsc)
+            }
+        }
+        return out
+    case json.RawMessage:
+        var arr []lsp.DocumentSymbol
+        if err := json.Unmarshal(v, &arr); err == nil {
+            out := make([]*lsp.DocumentSymbol, 0, len(arr))
+            for i := range arr {
+                out = append(out, &arr[i])
+            }
+            return out
+        }
+        var raw []interface{}
+        if err := json.Unmarshal(v, &raw); err == nil {
+            out := make([]*lsp.DocumentSymbol, 0, len(raw))
+            for _, it := range raw {
+                if ds, err := jsonutil.Convert[lsp.DocumentSymbol](it); err == nil && ds.Name != "" {
+                    dsc := ds
+                    out = append(out, &dsc)
+                }
+            }
+            return out
+        }
+        return nil
+    default:
+        return nil
+    }
+}
+
+// ParseDocumentSymbolsToSymbolInformation converts documentSymbol responses to []types.SymbolInformation
+// using the provided defaultURI to populate locations.
+func ParseDocumentSymbolsToSymbolInformation(result interface{}, defaultURI string) []types.SymbolInformation {
+    // First try to get DocumentSymbols, then map to SymbolInformation
+    docSyms := ParseDocumentSymbols(result)
+    if len(docSyms) > 0 {
+        out := make([]types.SymbolInformation, 0, len(docSyms))
+        for _, ds := range docSyms {
+            if ds == nil {
+                continue
+            }
+            si := types.SymbolInformation{
+                Name: ds.Name,
+                Kind: ds.Kind,
+                Location: types.Location{
+                    URI:   defaultURI,
+                    Range: ds.Range,
+                },
+            }
+            // preserve selection range via pointer
+            sel := ds.SelectionRange
+            si.SelectionRange = &sel
+            out = append(out, si)
+        }
+        return out
+    }
+
+    // Otherwise, attempt to parse directly as SymbolInformation array
+    switch v := result.(type) {
+    case []types.SymbolInformation:
+        return v
+    case []interface{}:
+        out := make([]types.SymbolInformation, 0, len(v))
+        for _, it := range v {
+            if si, err := jsonutil.Convert[types.SymbolInformation](it); err == nil && si.Name != "" {
+                out = append(out, si)
+            }
+        }
+        return out
+    case json.RawMessage:
+        var arr []types.SymbolInformation
+        if err := json.Unmarshal(v, &arr); err == nil {
+            return arr
+        }
+        var raw []interface{}
+        if err := json.Unmarshal(v, &raw); err == nil {
+            out := make([]types.SymbolInformation, 0, len(raw))
+            for _, it := range raw {
+                if si, err := jsonutil.Convert[types.SymbolInformation](it); err == nil && si.Name != "" {
+                    out = append(out, si)
+                }
+            }
+            return out
+        }
+    }
+    return nil
+}
+


### PR DESCRIPTION
P0 refactors:
- Add utils/filepattern.Match and adopt in cache + references search
- Centralize workspace/document symbol parsing in utils/lspconv (ParseWorkspaceSymbols, ParseDocumentSymbols, ParseDocumentSymbolsToSymbolInformation)
- Replace ad-hoc Marshal/Unmarshal/Convert code in references and indexer
- Remove redundant parseLocationResponse wrapper; use lspconv.ParseLocations directly
- Fix documents EnsureOpen to avoid extra workspace folder notifications; tests pass

Build + Tests:
- go build ./... OK
- go test ./... OK
